### PR TITLE
fix : MyRecipeController getRecipeOptionValues URL 변경(#100)

### DIFF
--- a/Cockpybara/src/main/java/Alchole_free/Cockpybara/controller/my_recipe/MyRecipeController.java
+++ b/Cockpybara/src/main/java/Alchole_free/Cockpybara/controller/my_recipe/MyRecipeController.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class MyRecipeController {
     private final CocktailRecipeService cocktailRecipeService;
 
-    @GetMapping
+    @GetMapping("/filter-values")
     public ResponseEntity<RecipeOptionsResponse> getRecipeOptionValues() {
         RecipeOptionsResponse recipeOptionsResponse = new RecipeOptionsResponse(
                 Glass.values(),


### PR DESCRIPTION
IngredientController의 searchIngredientByName 메서드와 HTTP메서드, URL이 동일하여 에러가 발생하는 부분 수정